### PR TITLE
Use Go 1.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine
+FROM golang:1.10-alpine3.8
 
 ARG APP_PATH=github.com/JiscRDSS/rdss-archivematica-msgcreator
 


### PR DESCRIPTION
Use Go 1.10 so we don't have to set extra envs to ignore the vendor directory.